### PR TITLE
Feat/#50

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ dependencies {
 	implementation 'me.paulschwarz:spring-dotenv:3.0.0'
 
 	//Swagger
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
 
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 }

--- a/src/main/java/LittlePet/UMC/Badge/controller/BadgeController.java
+++ b/src/main/java/LittlePet/UMC/Badge/controller/BadgeController.java
@@ -1,0 +1,60 @@
+package LittlePet.UMC.Badge.controller;
+
+import LittlePet.UMC.Badge.converter.BadgeConverter;
+import LittlePet.UMC.Badge.converter.UserBadgeConverter;
+import LittlePet.UMC.Badge.dto.BadgeResponseDTO;
+import LittlePet.UMC.Badge.service.BadgeCommandService;
+import LittlePet.UMC.Badge.validation.annotation.ExistBadgeType;
+import LittlePet.UMC.Badge.validation.annotation.ExistUser;
+import LittlePet.UMC.apiPayload.ApiResponse;
+import LittlePet.UMC.domain.BadgeEntity.Badge;
+import LittlePet.UMC.domain.BadgeEntity.UserBadge;
+import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+//validation 및 errorstatus 추가해야됨
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/badge")
+@Validated
+public class BadgeController {
+
+    private final BadgeCommandService badgeCommandService;
+
+    @PostMapping("/{userId}/{badgetype}/check")
+    public ApiResponse<BadgeResponseDTO.badgeResultDTO> checkBadges(
+            @PathVariable @ExistUser Long userId,
+            @PathVariable @ExistBadgeType String badgetype)
+    {
+        UserBadge new_userbadge  = badgeCommandService.checkBadges(userId,badgetype);
+        return ApiResponse.onSuccess(BadgeConverter.toBadgeResponseDTO(new_userbadge));
+    }
+
+    @PostMapping("/challengers")//이미 받은 사람 못받게 수정 추가해야됨
+    public ApiResponse<List<BadgeResponseDTO.ChallengerResultDTO>> addChallenger()
+    {
+        List<UserBadge> challenger_userbadge  = badgeCommandService.assignChallenger();
+        return ApiResponse.onSuccess(UserBadgeConverter.tochallengersDTO(challenger_userbadge));
+    }
+
+    @GetMapping("/{userId}")
+    public ApiResponse<BadgeResponseDTO.getBadgeResultDTO> getUserBadges(
+            @PathVariable @ExistUser Long userId)
+
+    {
+        List<Badge> badges = badgeCommandService.getBadgesByUserId(userId);
+        return ApiResponse.onSuccess(BadgeConverter.toGetBadgeResuletDTO(badges));
+    }
+    @DeleteMapping("/{userId}/{badgetype}/delete")
+    public ApiResponse<BadgeResponseDTO.badgeResultDTO> deleteBadge(
+            @PathVariable @ExistUser Long userId,
+            @PathVariable @ExistBadgeType String badgetype)
+    {
+            UserBadge deleted_UserBadge = badgeCommandService.deleteUserBadge(userId, badgetype);
+            return ApiResponse.onSuccess(BadgeConverter.toBadgeResponseDTO(deleted_UserBadge));
+    }
+}
+

--- a/src/main/java/LittlePet/UMC/Badge/converter/BadgeConverter.java
+++ b/src/main/java/LittlePet/UMC/Badge/converter/BadgeConverter.java
@@ -1,0 +1,37 @@
+package LittlePet.UMC.Badge.converter;
+
+import LittlePet.UMC.Badge.dto.BadgeResponseDTO;
+import LittlePet.UMC.domain.BadgeEntity.Badge;
+import LittlePet.UMC.domain.BadgeEntity.UserBadge;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class BadgeConverter {
+
+    public static BadgeResponseDTO.badgeResultDTO toBadgeResponseDTO(UserBadge userBadge) {
+        return BadgeResponseDTO.badgeResultDTO.builder()
+                .userId(userBadge.getUser().getId())
+                .badgeId(userBadge.getBadge().getId())
+                .name(userBadge.getBadge().getName())
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
+
+    public static BadgeResponseDTO.getBadgeResultDTO toGetBadgeResuletDTO(List<Badge> badges) {
+        // badges가 null인 경우 null 반환
+        if (badges == null) {
+            return null;
+        }
+
+        List<String> list =badges.stream()
+                .map(Badge::getName)
+                .collect(Collectors.toList());
+
+        return BadgeResponseDTO.getBadgeResultDTO.builder()
+                .badgeTypeList(list).build();
+
+    }
+}
+//List<BadgeType>

--- a/src/main/java/LittlePet/UMC/Badge/converter/UserBadgeConverter.java
+++ b/src/main/java/LittlePet/UMC/Badge/converter/UserBadgeConverter.java
@@ -1,0 +1,35 @@
+package LittlePet.UMC.Badge.converter;
+
+import LittlePet.UMC.Badge.dto.BadgeResponseDTO;
+import LittlePet.UMC.domain.BadgeEntity.Badge;
+import LittlePet.UMC.domain.BadgeEntity.UserBadge;
+import LittlePet.UMC.domain.userEntity.User;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class UserBadgeConverter {
+    public static List<UserBadge> toUserBadgeList(List<User> userList, Badge Challenger) {
+        return userList.stream()
+                .map(user ->
+                    UserBadge.builder()
+                            .badge(Challenger)
+                            .user(user)
+                            .build()
+                ).collect(Collectors.toList());
+
+    }
+
+    public static List<BadgeResponseDTO.ChallengerResultDTO> tochallengersDTO(List<UserBadge> challengerUserbadge) {
+        return challengerUserbadge.stream()
+                .map(challenger ->
+                        BadgeResponseDTO.ChallengerResultDTO.builder()
+                                .badgetype(challenger.getBadge().getName())
+                                .userid(challenger.getUser().getId())
+                                .createdAt(LocalDateTime.now())
+                                .build()
+                ).collect(Collectors.toList());
+    }
+}

--- a/src/main/java/LittlePet/UMC/Badge/dto/BadgeResponseDTO.java
+++ b/src/main/java/LittlePet/UMC/Badge/dto/BadgeResponseDTO.java
@@ -1,0 +1,42 @@
+package LittlePet.UMC.Badge.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class BadgeResponseDTO {
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class badgeResultDTO {
+        Long userId;
+        Long badgeId;
+        String name;
+        LocalDateTime createdAt;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class getBadgeResultDTO {
+        List<String> badgeTypeList;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ChallengerResultDTO {
+        Long userid;
+        String badgetype;
+        LocalDateTime createdAt;
+
+    }
+}
+

--- a/src/main/java/LittlePet/UMC/Badge/repository/badgeRepository/BadgeRepository.java
+++ b/src/main/java/LittlePet/UMC/Badge/repository/badgeRepository/BadgeRepository.java
@@ -1,0 +1,14 @@
+package LittlePet.UMC.Badge.repository.badgeRepository;
+
+import LittlePet.UMC.domain.BadgeEntity.Badge;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface BadgeRepository extends JpaRepository<Badge, Long> ,BadgeRepositoryCustom {
+    @Query("SELECT CASE WHEN COUNT(b) > 0 THEN TRUE ELSE FALSE END FROM Badge b WHERE b.name = :badgeType")
+    boolean existByBadgeType(@Param("badgeType") String badgeType);
+
+
+
+}

--- a/src/main/java/LittlePet/UMC/Badge/repository/badgeRepository/BadgeRepositoryCustom.java
+++ b/src/main/java/LittlePet/UMC/Badge/repository/badgeRepository/BadgeRepositoryCustom.java
@@ -1,0 +1,12 @@
+package LittlePet.UMC.Badge.repository.badgeRepository;
+
+import LittlePet.UMC.domain.BadgeEntity.Badge;
+
+public interface BadgeRepositoryCustom {
+//    Optional<UserBadge> findByUserIdAndBadgeId(Long userId, Long badgeId);
+//    List<UserBadge> findByUserId(Long userId);
+
+    Badge findByBadgeType(String badgeType);
+
+
+}

--- a/src/main/java/LittlePet/UMC/Badge/repository/badgeRepository/BadgeRepositoryImpl.java
+++ b/src/main/java/LittlePet/UMC/Badge/repository/badgeRepository/BadgeRepositoryImpl.java
@@ -1,0 +1,28 @@
+package LittlePet.UMC.Badge.repository.badgeRepository;
+
+import LittlePet.UMC.domain.BadgeEntity.Badge;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class BadgeRepositoryImpl implements BadgeRepositoryCustom {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+
+    @Override
+    public Badge findByBadgeType(String badgeType) {
+        String jpql = "SELECT b FROM Badge b WHERE b.name = :badgeType";
+        Badge badge = entityManager.createQuery(jpql, Badge.class)
+                .setParameter("badgeType", badgeType)
+                .getSingleResult();
+        return badge;
+    }
+
+
+
+}

--- a/src/main/java/LittlePet/UMC/Badge/repository/badgeRepository/UserBadgeRepository.java
+++ b/src/main/java/LittlePet/UMC/Badge/repository/badgeRepository/UserBadgeRepository.java
@@ -1,0 +1,29 @@
+package LittlePet.UMC.Badge.repository.badgeRepository;
+
+import LittlePet.UMC.domain.BadgeEntity.Badge;
+import LittlePet.UMC.domain.BadgeEntity.UserBadge;
+import LittlePet.UMC.domain.userEntity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Collection;
+import java.util.List;
+
+public interface UserBadgeRepository extends JpaRepository<UserBadge, Integer> {
+
+    Collection<UserBadge> findByUserId(Long userId);
+
+
+    @Modifying
+    @Query("DELETE FROM UserBadge ub WHERE ub.user.id = :userId AND ub.badge.id = :badgeId")
+    void deleteByUserAndBadge(Long userId, Long badgeId);
+
+    @Query("SELECT ub FROM UserBadge ub WHERE ub.user = :user AND ub.badge = :badge")
+    UserBadge findByUserIdandBadgeType(@Param("user") User user, @Param("badge") Badge badge);
+
+    boolean existsByUserAndBadge(User user, Badge badge);
+
+
+}

--- a/src/main/java/LittlePet/UMC/Badge/service/BadgeCommandService.java
+++ b/src/main/java/LittlePet/UMC/Badge/service/BadgeCommandService.java
@@ -1,0 +1,20 @@
+package LittlePet.UMC.Badge.service;
+
+import LittlePet.UMC.domain.BadgeEntity.Badge;
+import LittlePet.UMC.domain.BadgeEntity.UserBadge;
+import LittlePet.UMC.domain.userEntity.User;
+
+import java.util.List;
+
+public interface BadgeCommandService {
+    UserBadge checkBadges(Long userId, String badgeType);
+
+    UserBadge assignBadge(User user, String badgeType, boolean criteriaMet);
+
+    List<Badge> getBadgesByUserId(Long userId);
+
+    List<UserBadge> assignChallenger();
+
+    UserBadge deleteUserBadge(Long userId, String badgeType);
+
+}

--- a/src/main/java/LittlePet/UMC/Badge/service/BadgeCommandServiceImpl.java
+++ b/src/main/java/LittlePet/UMC/Badge/service/BadgeCommandServiceImpl.java
@@ -1,0 +1,167 @@
+package LittlePet.UMC.Badge.service;
+
+import LittlePet.UMC.Badge.converter.UserBadgeConverter;
+import LittlePet.UMC.Badge.repository.badgeRepository.BadgeRepository;
+import LittlePet.UMC.Badge.repository.badgeRepository.UserBadgeRepository;
+import LittlePet.UMC.User.repository.UserRepository;
+import LittlePet.UMC.apiPayload.code.status.ErrorStatus;
+import LittlePet.UMC.apiPayload.exception.handler.BadgeHandler;
+import LittlePet.UMC.community.repository.CommentRepository;
+import LittlePet.UMC.community.repository.PostLlikeRepository;
+import LittlePet.UMC.community.repository.PostRepository;
+import LittlePet.UMC.domain.BadgeEntity.Badge;
+import LittlePet.UMC.domain.BadgeEntity.UserBadge;
+import LittlePet.UMC.domain.userEntity.User;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class BadgeCommandServiceImpl implements BadgeCommandService {
+    private final BadgeRepository badgeRepository;
+
+    private final UserRepository userRepository;
+
+    private final PostRepository postRepository;
+
+    private final UserBadgeRepository userBadgeRepository;
+
+    private final PostLlikeRepository postLlikeRepository;
+
+    private final CommentRepository commentRepository;
+
+    @Override
+    public UserBadge checkBadges(Long userId,String badgeType) {
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("User not found")); //바꿔야함 validation
+
+        boolean criteriaMet = false;
+        // 문자열을 Enum으로 변환
+        switch (badgeType) {
+            case "글쓰기마스터":
+                long postCount = postRepository.countByUserId(userId);
+                criteriaMet = postCount >= 1; // Test를 위해 일단 1개 ,원래 15개 이상이면 True
+                break;
+
+            case "소통천재":
+                long commentCount = commentRepository.getCountByUserId(userId); // 댓글 수 가져오기 (추가 메서드 필요)
+                criteriaMet = commentCount >= 1; // Test를 위해 일단 1개 30개 이상이면 True
+                break;
+
+            case "소셜응원왕":
+                long likeCount = postLlikeRepository.getCountByUserId(userId); // 좋아요 수 가져오기 (추가 메서드 필요)
+                criteriaMet = likeCount >= 1; // Test를 위해 일단 1개 50개 이상이면 True
+                break;
+
+//            case "CHALLENGER":
+
+            case "인기스타":
+                long totalLikesReceived = postRepository.getTotalLikesReceivedByUserId(userId); // 유저가 받은 좋아요 총합
+                criteriaMet = totalLikesReceived >= 2; // 좋아요 수 30개 이상
+                break;
+
+            default:
+                log.error("Invalid badge type: {}", badgeType);
+                throw new IllegalArgumentException("Invalid badge type");
+        }
+        if (criteriaMet) {
+            log.info("Criteria met for badge type: {}", badgeType);
+        } else {
+            log.info("Criteria not met for badge type: {}", badgeType);
+        }
+
+        return assignBadge(user, badgeType, criteriaMet);
+
+    }
+
+    @Override
+    @Transactional
+    public UserBadge assignBadge(User user, String badgeType, boolean criteriaMet) {
+        log.info("메소드 시작:"+user+badgeType+criteriaMet);
+        if (!criteriaMet) {
+            // 조건을 충족하지 못함
+            throw new BadgeHandler(ErrorStatus.BADGE_NOT_QUALIFIED);
+        }
+
+        // 이미 뱃지가 할당된 경우 처리
+        boolean alreadyHasBadge = user.getUserBadgeList().stream()
+                .anyMatch(userBadge -> userBadge.getBadge().getName().equals(badgeType));
+
+        if (alreadyHasBadge) {
+            log.info("already has badge for badge type: {}", badgeType);
+            // 이미 뱃지를 보유하고 있다면 예외를 던짐
+            throw new BadgeHandler(ErrorStatus.BADGE_ALREADY_OWNED);
+        }
+
+        Badge badge = badgeRepository.findByBadgeType(badgeType);
+
+        UserBadge userBadge = UserBadge.builder()
+                .user(user)
+                .badge(badge)
+                .build();
+
+        user.getUserBadgeList().add(userBadge);
+        userRepository.save(user);
+        return userBadge;
+    }
+
+    @Override
+    public List<Badge> getBadgesByUserId(Long userId) {
+
+        // 사용자의 모든 UserBadge 조회 후 Badge 리스트 반환
+        List<Badge> BadgeList = userBadgeRepository.findByUserId(userId).stream()
+                                        .map(UserBadge::getBadge)
+                                        .collect(Collectors.toList());
+        return BadgeList;
+    }
+
+    @Override
+    @Transactional
+    public List<UserBadge> assignChallenger() {
+        List<Long> userIdList = postLlikeRepository.findTopUsersByChallenge();
+
+        // 해당 ID로 User 리스트 조회
+        List<User> userList = userRepository.findAllById(userIdList);
+
+        Badge challengerBadge = badgeRepository.findByBadgeType("챌린저");
+
+        // 이미 챌린저 뱃지를 가진 유저 제거
+        userList.removeIf(user -> userBadgeRepository.existsByUserAndBadge(user, challengerBadge));
+
+        List<UserBadge> UserBadgeList  = UserBadgeConverter.toUserBadgeList(userList,challengerBadge);
+
+        UserBadgeList.forEach(UserBadge -> {UserBadge.setUser();});
+
+        userRepository.saveAll(userList);
+        return UserBadgeList;
+
+    }
+
+    @Override
+    @Transactional
+    public UserBadge deleteUserBadge(Long userId, String badgeType) {
+        // 유저 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("User not found"));
+        // 뱃지 타입에 해당하는 뱃지 조회
+        Badge badge = badgeRepository.findByBadgeType(badgeType);
+
+        UserBadge deletedUserBadge = userBadgeRepository.findByUserIdandBadgeType(user,badge);
+        // UserBadge 엔티티 삭제
+        userBadgeRepository.deleteByUserAndBadge(user.getId(), badge.getId());
+
+        return deletedUserBadge;
+    }
+
+
+}
+
+

--- a/src/main/java/LittlePet/UMC/Badge/validation/annotation/ExistBadgeType.java
+++ b/src/main/java/LittlePet/UMC/Badge/validation/annotation/ExistBadgeType.java
@@ -1,0 +1,17 @@
+package LittlePet.UMC.Badge.validation.annotation;
+
+import LittlePet.UMC.Badge.validation.validator.BadgeTypeExistValidator;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = BadgeTypeExistValidator.class)
+@Target( { ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ExistBadgeType {
+    String message() default "'POST_MASTER' , 'COMMENT_GENIUS', 'LIKE_KING' 중에 선택해주세요";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/LittlePet/UMC/Badge/validation/annotation/ExistUser.java
+++ b/src/main/java/LittlePet/UMC/Badge/validation/annotation/ExistUser.java
@@ -1,0 +1,17 @@
+package LittlePet.UMC.Badge.validation.annotation;
+
+import LittlePet.UMC.Badge.validation.validator.UserExistValidator;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = UserExistValidator.class)
+@Target( { ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ExistUser {
+    String message() default "유저 아이디를 다시 한번 확인해주세요";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/LittlePet/UMC/Badge/validation/validator/BadgeTypeExistValidator.java
+++ b/src/main/java/LittlePet/UMC/Badge/validation/validator/BadgeTypeExistValidator.java
@@ -1,0 +1,34 @@
+package LittlePet.UMC.Badge.validation.validator;
+
+import LittlePet.UMC.Badge.repository.badgeRepository.BadgeRepository;
+import LittlePet.UMC.Badge.validation.annotation.ExistBadgeType;
+import LittlePet.UMC.User.repository.UserRepository;
+import LittlePet.UMC.apiPayload.code.status.ErrorStatus;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class BadgeTypeExistValidator implements ConstraintValidator<ExistBadgeType,String> {
+
+
+    private final BadgeRepository badgeRepository;
+    @Override
+    public void initialize(ExistBadgeType constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+    }
+
+    @Override
+    public boolean isValid(String s, ConstraintValidatorContext context) {
+        Boolean isValid = badgeRepository.existByBadgeType(s);
+
+        if (!isValid) {
+            context.disableDefaultConstraintViolation();
+            context.buildConstraintViolationWithTemplate(ErrorStatus.BADGE_NOT_FOUND.toString()).addConstraintViolation();
+
+        }
+        return isValid;
+    }
+}

--- a/src/main/java/LittlePet/UMC/Badge/validation/validator/UserExistValidator.java
+++ b/src/main/java/LittlePet/UMC/Badge/validation/validator/UserExistValidator.java
@@ -1,0 +1,35 @@
+package LittlePet.UMC.Badge.validation.validator;
+
+import LittlePet.UMC.Badge.validation.annotation.ExistUser;
+import LittlePet.UMC.User.repository.UserRepository;
+import LittlePet.UMC.apiPayload.code.status.ErrorStatus;
+import LittlePet.UMC.domain.userEntity.User;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class UserExistValidator implements ConstraintValidator<ExistUser, Long> {
+
+    private final UserRepository userRepository;
+
+
+    @Override
+    public void initialize(ExistUser constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+    }
+
+    @Override
+    public boolean isValid(Long UserId, ConstraintValidatorContext context) {
+        Boolean isValid = userRepository.existsById(UserId);
+
+        if (!isValid) {
+            context.disableDefaultConstraintViolation();
+            context.buildConstraintViolationWithTemplate(ErrorStatus.USER_NOT_FOUND.toString()).addConstraintViolation();
+
+        }
+        return isValid;
+    }
+}

--- a/src/main/java/LittlePet/UMC/User/repository/UserRepository.java
+++ b/src/main/java/LittlePet/UMC/User/repository/UserRepository.java
@@ -1,4 +1,10 @@
 package LittlePet.UMC.User.repository;
 
-public interface UserRepository {
+import LittlePet.UMC.domain.userEntity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
 }

--- a/src/main/java/LittlePet/UMC/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/LittlePet/UMC/apiPayload/code/status/ErrorStatus.java
@@ -43,8 +43,15 @@ public enum ErrorStatus implements BaseErrorCode {
     INVALID_CATEGORY(HttpStatus.BAD_REQUEST, "CATEGORY4003", "유효하지 않은 카테고리입니다."),
 
     // 테스트용
-    TEMP_EXCEPTION(HttpStatus.BAD_REQUEST, "TEMP4004", "테스트입니다");
+    TEMP_EXCEPTION(HttpStatus.BAD_REQUEST, "TEMP4004", "테스트입니다"),
 
+    //유저 관련 에러
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER4041","존재하지 않는 유저입니다."),
+
+    //뱃지 타입 관련 에러
+    BADGE_NOT_FOUND(HttpStatus.NOT_FOUND, "BADGE4041","존재하지 않는 뱃지입니다. '글쓰기마스터' , '소통천재', '소통응원왕','인기스타' 중 하나를 선택해주세요"),
+    BADGE_ALREADY_OWNED(HttpStatus.BAD_REQUEST, "BADGE4001", "이미 해당 뱃지를 보유하고 있습니다. '글쓰기마스터' , '소통천재', '소통응원왕','인기스타' 중 다른 뱃지를 선택해주세요"),
+    BADGE_NOT_QUALIFIED(HttpStatus.BAD_REQUEST, "BADGE4002","뱃지를 받을 조건이 충족되지않았습니다.");
     private final HttpStatus httpStatus;
     private final String code;
     private final String message;

--- a/src/main/java/LittlePet/UMC/apiPayload/exception/handler/BadgeHandler.java
+++ b/src/main/java/LittlePet/UMC/apiPayload/exception/handler/BadgeHandler.java
@@ -1,0 +1,10 @@
+package LittlePet.UMC.apiPayload.exception.handler;
+
+import LittlePet.UMC.apiPayload.code.BaseErrorCode;
+import LittlePet.UMC.apiPayload.exception.GeneralException;
+
+public class BadgeHandler extends GeneralException {
+    public BadgeHandler(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/LittlePet/UMC/community/repository/CommentRepository.java
+++ b/src/main/java/LittlePet/UMC/community/repository/CommentRepository.java
@@ -1,0 +1,12 @@
+package LittlePet.UMC.community.repository;
+
+import LittlePet.UMC.domain.postEntity.mapping.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+    @Query("SELECT COUNT(c) FROM Comment c WHERE c.user.id = :userId")
+    long getCountByUserId(@Param("userId") Long userId);
+
+}

--- a/src/main/java/LittlePet/UMC/community/repository/PostLlikeRepository.java
+++ b/src/main/java/LittlePet/UMC/community/repository/PostLlikeRepository.java
@@ -1,0 +1,25 @@
+package LittlePet.UMC.community.repository;
+
+import LittlePet.UMC.domain.postEntity.PostCategory;
+import LittlePet.UMC.domain.postEntity.mapping.PostLike;
+import LittlePet.UMC.domain.userEntity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface PostLlikeRepository extends JpaRepository<PostLike,Long> {
+    @Query("SELECT COUNT(l) FROM PostLike l WHERE l.user.id = :userId")
+    long getCountByUserId(@Param("userId") Long userId);
+
+    @Query(value = "SELECT po.user_id FROM post_like p " +
+            "JOIN post po ON p.post_id = po.id " +
+            "JOIN post_category pc ON po.postcategory_id = pc.id " +
+            "WHERE pc.category = '챌린지' " +
+            "GROUP BY p.user_id " +
+            "ORDER BY COUNT(p.id) DESC " +
+            "LIMIT 3", nativeQuery = true)
+    List<Long> findTopUsersByChallenge();
+
+}

--- a/src/main/java/LittlePet/UMC/community/repository/PostRepository.java
+++ b/src/main/java/LittlePet/UMC/community/repository/PostRepository.java
@@ -1,0 +1,16 @@
+package LittlePet.UMC.community.repository;
+
+import LittlePet.UMC.domain.postEntity.Post;
+import LittlePet.UMC.domain.postEntity.mapping.PostLike;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface PostRepository extends JpaRepository<Post, Long> {
+    @Query("SELECT COUNT(p) FROM Post p WHERE p.user.id = :userId")
+    long countByUserId(@Param("userId") Long userId);
+
+    @Query("SELECT COUNT(pl) FROM PostLike pl WHERE pl.post.user.id = :userId")
+    long getTotalLikesReceivedByUserId(@Param("userId") Long userId);
+
+}

--- a/src/main/java/LittlePet/UMC/domain/BadgeEntity/UserBadge.java
+++ b/src/main/java/LittlePet/UMC/domain/BadgeEntity/UserBadge.java
@@ -25,4 +25,8 @@ public class UserBadge extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "badge_id",nullable = false)
     private Badge badge;
+
+    public void setUser(){
+        user.getUserBadgeList().add(this);
+    }
 }

--- a/src/main/java/LittlePet/UMC/domain/userEntity/User.java
+++ b/src/main/java/LittlePet/UMC/domain/userEntity/User.java
@@ -82,4 +82,9 @@ public class User extends BaseTimeEntity {
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
     private List<UserBadge> userBadgeList= new ArrayList<>();
 
+    @Override
+    public String toString() {
+        return "User{id=" + id + ", username='" + name + "', email='" + email + "'}";
+    }
+
 }

--- a/src/main/java/LittlePet/UMC/repository/badgeRepository/BadgeRepository.java
+++ b/src/main/java/LittlePet/UMC/repository/badgeRepository/BadgeRepository.java
@@ -1,7 +1,0 @@
-package LittlePet.UMC.repository.badgeRepository;
-
-import LittlePet.UMC.domain.BadgeEntity.Badge;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface BadgeRepository extends JpaRepository<Badge, Integer> {
-}

--- a/src/main/java/LittlePet/UMC/repository/badgeRepository/UserBadgeRepository.java
+++ b/src/main/java/LittlePet/UMC/repository/badgeRepository/UserBadgeRepository.java
@@ -1,7 +1,0 @@
-package LittlePet.UMC.repository.badgeRepository;
-
-import LittlePet.UMC.domain.BadgeEntity.UserBadge;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface UserBadgeRepository extends JpaRepository<UserBadge, Integer> {
-}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,7 +6,7 @@ spring:
     driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQL8Dialect

--- a/src/test/java/LittlePet/UMC/repository/badgeRepository/BadgeRepositoryTest.java
+++ b/src/test/java/LittlePet/UMC/repository/badgeRepository/BadgeRepositoryTest.java
@@ -1,5 +1,6 @@
 package LittlePet.UMC.repository.badgeRepository;
 
+import LittlePet.UMC.Badge.repository.badgeRepository.BadgeRepository;
 import LittlePet.UMC.UmcApplication;
 import LittlePet.UMC.domain.BadgeEntity.Badge;
 import org.junit.jupiter.api.DisplayName;

--- a/src/test/java/LittlePet/UMC/repository/badgeRepository/UserBadgeRepositoryTest.java
+++ b/src/test/java/LittlePet/UMC/repository/badgeRepository/UserBadgeRepositoryTest.java
@@ -1,5 +1,7 @@
 package LittlePet.UMC.repository.badgeRepository;
 
+import LittlePet.UMC.Badge.repository.badgeRepository.BadgeRepository;
+import LittlePet.UMC.Badge.repository.badgeRepository.UserBadgeRepository;
 import LittlePet.UMC.UmcApplication;
 import LittlePet.UMC.domain.BadgeEntity.Badge;
 import LittlePet.UMC.domain.BadgeEntity.UserBadge;

--- a/src/test/java/LittlePet/UMC/repository/postRepository/mapping/CommentRepositoryTest.java
+++ b/src/test/java/LittlePet/UMC/repository/postRepository/mapping/CommentRepositoryTest.java
@@ -1,6 +1,7 @@
 package LittlePet.UMC.repository.postRepository.mapping;
 
 import LittlePet.UMC.UmcApplication;
+import LittlePet.UMC.community.repository.CommentRepository;
 import LittlePet.UMC.domain.enums.Gender;
 import LittlePet.UMC.domain.enums.RoleStatus;
 import LittlePet.UMC.domain.enums.SocialProviderEnum;


### PR DESCRIPTION
## Related Issue 🛠
- Closes #<50>

## Description ✏️
- 뱃지 API 생성 

## Work Details 🛠
- 주요 변경 사항:
  - swagger 버전 바꿈 
  - 챌린저 뱃지를 위한 API를 새로 만듬
  - Badge API를 위한 여러 레포지토리를 만듬(UserRepository,PostLikeRepository)

## Checklist 📋
- [x] 코드가 정상적으로 동작하는지 확인했습니다.
- [x] 코드 리뷰를 요청했습니다.
- [x] 필요한 문서를 업데이트했습니다.
- [ ] 모든 테스트를 통과했습니다.

## Screenshots 📷
- 변경된 UI나 주요 작업 내용을 스크린샷으로 첨부하세요 (필요 시).

## Additional Notes 📝
- 뱃지 API는 그 자체로 쓰기 보다 여러 API에 내부로직에 들어갈 필요를 느낌
- 예를 들어 게시글을 하나 생성하면 BadgeAPI에 있는 Service를 통해 게시글 갯수 조건을 확인 후 뱃지를 주는 방식
이를 위해 게시글을 만드는 API의 Service에 들어가야 한다고 생각함
